### PR TITLE
year corrections to reflect the `dat` dataset after filtering & mutate

### DIFF
--- a/_blog/running-longitudinal-random-forests-with-longiturf/running-longitudinal-random-forests-with-longiturf.Rmd
+++ b/_blog/running-longitudinal-random-forests-with-longiturf/running-longitudinal-random-forests-with-longiturf.Rmd
@@ -233,7 +233,7 @@ The model likes getting data in a specific way. I am not a big fan of the specif
 
 ### Train Data
 
-From the years = 1 - 3 (i.e., 2015-2017). 
+From the years = 0 - 2 (i.e., 2015-2017). 
 
 ```{r}
 X <- 


### PR DESCRIPTION
The originally listed years "1 - 3" are understandable, but may not completely reflect the newly transformed values for the years. I've really enjoyed this blog post and spent a decent amount of time replicating and applying to one of my own. Thank you for taking the time to create this! ~Kyle